### PR TITLE
Added support for Arrays mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,39 @@ You may also specify defaults and transforms in two different ways:
 }
 ```
 
+Array objects mapping is also supported, but requires the Array brackets on both sides of mapping entry.
 
+
+```javascript
+//input
+{
+  inspired_by : ["node", "object", "mapper"],
+  limited_to  : [],
+  modified_by : [
+    {name: "John", change_id: "1", files: 6, title: "Added Arrays support"},
+    {name: "Jane", change_id: "2", files: 5, title: "Fixed some bugs"},
+    {name: "Josh", change_id: "3", files: 4, title: "Removed redundant files"}
+  ]
+}
+//array mapping scenarios
+{
+  // whole array mapping
+  "inspired_by" : "Result.Package.InspiredByArray",
+  // string members to objects mapping
+  "inspired_by[i]" : "Result.Package.InspiredBy[i].module",
+  // empty array copy
+  "limited_to[i]" : "Result.Package.LimitedTo[i]",
+  // object members properties to strings array mapping
+  "modified_by[i].name" : "Result.Package.Contributors[i]",
+  // using arrays with transform function
+  "modified_by[i]" : {key: "Result.Package.ChangeSummaries[i]",
+    transform: transform: function(member, objFrom, objTo) {
+      return member.name + ': ' member.title.substr(0, 10) + '...';
+    }
+  }
+};
+
+```
 
 
 methods
@@ -142,6 +174,55 @@ var result = merge(obj, {}, map);
 };
 */
 ```
+
+arrays example
+------------
+
+```javascript
+var obj = {
+  inspired_by : ["node", "object", "mapper"],
+  limited_to  : [],
+  modified_by : [
+    {name: "John", change_id: "1", files: 6, title: "Added Arrays support"},
+    {name: "Jane", change_id: "2", files: 5, title: "Fixed some bugs"},
+    {name: "Josh", change_id: "3", files: 4, title: "Removed redundant files"}
+  ]
+};
+
+var map = {
+  "inspired_by" : "Result.Package.InspiredByArray",
+  "inspired_by[i]" : "Result.Package.InspiredBy[i].module",
+  "limited_to[i]" : "Result.Package.LimitedTo[i]",
+  "modified_by[i].name" : "Result.Package.Contributors[i]",
+  "modified_by[i]" : {key: "Result.Package.ChangeSummaries[i]",
+    transform: transform: function(member, objFrom, objTo) {
+      return member.name + ': ' member.title.substr(0, 10) + '...';
+    }
+  }
+};
+
+var result = merge(obj, {}, map);
+
+// Expected
+{ 
+  Result: { 
+    Package: { 
+      InspiredByArray: ["node", "object", "mapper"],
+      InspiredBy: [
+        { module: "node" },
+        { module: "object" },
+        { module: "mapper" }
+      ],
+      LimitedTo: [],
+      Contributors: ["John", "Jane", "Josh"],
+      ChangeSummaries: [
+        "John: Added Arra...",
+        "Jane: Fixed some...",
+        "Josh: Removed re..."
+      ]
+    } 
+  } 
+};
 
 use case
 -------------

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ var expected = {
     } 
   } 
 };
+```
 
 use case
 -------------

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ var map = {
 var result = merge(obj, {}, map);
 
 // Expected
-{ 
+var expected = { 
   Result: { 
     Package: { 
       InspiredByArray: ["node", "object", "mapper"],

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ var result = merge(obj, {}, map);
 */
 ```
 
-arrays example
+arrays example (with constants)
 ------------
 
 ```javascript
@@ -190,6 +190,7 @@ var obj = {
 };
 
 var map = {
+  "\"NPM Module\"" : "Result.Package.Type", // Constant value mapping example
   "inspired_by" : "Result.Package.InspiredByArray",
   "inspired_by[i]" : "Result.Package.InspiredBy[i].module",
   "limited_to[i]" : "Result.Package.LimitedTo[i]",
@@ -206,6 +207,7 @@ var result = merge(obj, {}, map);
 // Expected
 var expected = { 
   Result: { 
+    Type: "NPM Module",
     Package: { 
       InspiredByArray: ["node", "object", "mapper"],
       InspiredBy: [

--- a/index.js
+++ b/index.js
@@ -110,7 +110,6 @@ function merge(objFrom, objTo, propMap) {
     , endFrom
     , startTo
     , endTo
-    , isArray
     , toArray
     , fromArray
     ;
@@ -150,12 +149,11 @@ function merge(objFrom, objTo, propMap) {
         }
 
         if (fromKey.indexOf('[') !== -1) {
-          isArray = true;
           startFrom = fromKey.substr(0, fromKey.indexOf('['));
           endFrom = fromKey.indexOf(']') + 2;
           endFrom = (endFrom < fromKey.length) ? fromKey.substr(endFrom) : null;
           fromArray = toArray = getKeyValue(objFrom, startFrom);
-          if (isArray && Array.isArray(fromArray)) {
+          if (Array.isArray(fromArray)) {
             if (key.indexOf('[') === -1) {
               throw "Target array mapping not exist!"
             }
@@ -169,7 +167,6 @@ function merge(objFrom, objTo, propMap) {
             setKeyValue(objTo, startTo, toArray);
           }
         } else {
-          isArray = false;
           _mergeSingle(objFrom, objTo, fromKey, key, transform, def);
         }
       }

--- a/index.js
+++ b/index.js
@@ -35,6 +35,9 @@ function getKeyValue(obj, key, undefined) {
     , x
     ;
   
+  if (key.indexOf('"') === 0) {
+    return key.substr(1, key.lastIndexOf('"') - 1);
+  }
   if (reg.test(key)) {
     keys = key.split(reg);
     context = obj;
@@ -148,7 +151,7 @@ function merge(objFrom, objTo, propMap) {
           def = def(objFrom, objTo);
         }
 
-        if (fromKey.indexOf('[') !== -1) {
+        if (fromKey.indexOf('[') !== -1 && fromKey.indexOf('"') !== 0) {
           startFrom = fromKey.substr(0, fromKey.indexOf('['));
           endFrom = fromKey.indexOf(']') + 2;
           endFrom = (endFrom < fromKey.length) ? fromKey.substr(endFrom) : null;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Dan VerWeire <dverweire@gmail.com>",
   "name": "object-mapper",
   "description": "Copy properties from one object to another.",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "repository": {
     "type": "git",
     "url": "git://github.com/wankdanker/node-object-mapper.git"

--- a/test/test.js
+++ b/test/test.js
@@ -114,4 +114,52 @@ assert.deepEqual(
   , "Fail! Transform failed"
 );
 
+var obj = {
+  inspired_by : ["node", "object", "mapper"],
+  limited_to  : [],
+  modified_by : [
+    {name: "John", change_id: "1", files: 6, title: "Added Arrays support"},
+    {name: "Jane", change_id: "2", files: 5, title: "Fixed some bugs"},
+    {name: "Josh", change_id: "3", files: 4, title: "Removed redundant files"}
+  ]
+};
+
+var map = {
+  "inspired_by" : "Result.Package.InspiredByArray",
+  "inspired_by[i]" : "Result.Package.InspiredBy[i].module",
+  "limited_to[i]" : "Result.Package.LimitedTo[i]",
+  "modified_by[i].name" : "Result.Package.Contributors[i]",
+  "modified_by[i]" : {key: "Result.Package.ChangeSummaries[i]",
+    transform: function(member, objFrom, objTo) {
+      return member.name + ': ' + member.title.substr(0, 10) + '...';
+    }
+  }
+};
+
+var expected = { 
+  Result: { 
+    Package: { 
+      InspiredByArray: ["node", "object", "mapper"],
+      InspiredBy: [
+        { module: "node" },
+        { module: "object" },
+        { module: "mapper" }
+      ],
+      LimitedTo: [],
+      Contributors: ["John", "Jane", "Josh"],
+      ChangeSummaries: [
+        "John: Added Arra...",
+        "Jane: Fixed some...",
+        "Josh: Removed re..."
+      ]
+    } 
+  } 
+};
+
+assert.deepEqual(
+  merge(obj, {}, map)
+  , expected
+  , "Fail! Arrays mapping failed"
+);
+
 console.error("Success!");

--- a/test/test.js
+++ b/test/test.js
@@ -125,6 +125,8 @@ var obj = {
 };
 
 var map = {
+  "\"NPM Module\"" : "Result.Package.Type",
+  "\"NPM Module" : "Result.Package.Type2", // This value will be omitted since there is no closing tag
   "inspired_by" : "Result.Package.InspiredByArray",
   "inspired_by[i]" : "Result.Package.InspiredBy[i].module",
   "limited_to[i]" : "Result.Package.LimitedTo[i]",
@@ -138,7 +140,8 @@ var map = {
 
 var expected = { 
   Result: { 
-    Package: { 
+    Package: {
+      Type: "NPM Module",
       InspiredByArray: ["node", "object", "mapper"],
       InspiredBy: [
         { module: "node" },

--- a/test/test.js
+++ b/test/test.js
@@ -14,18 +14,50 @@ var obj = {
     "onHandQty" : 12
     , "replenishQty" : null
   }
+  , "shipping" : {
+    "methods" : [
+      {"name" : "DHL Global Mail (2-8 weeks)", "price" : 25}
+      , {"name" : "Intl USPS w/tracking (1-3 weeks)", "price" : 35}
+      , {"name" : "UPS Worldwide Express", "price" : 63}
+    ]
+    , "options" : []
+  }
+};
+
+function shortener(shortNum) {
+  return function(value, objFrom, objTo) {
+    return value.substr(0, shortNum) + '...';
+  }
 }
 
 var map = {
   "sku" : "Envelope.Request.Item.SKU"
   , "upc" : "Envelope.Request.Item.UPC"
   , "title" : "Envelope.Request.Item.ShortTitle"
-  , "description" : "Envelope.Request.Item.ShortDescription"
+    // Example of multiple TO values. Second with transformation.
+  , "description" : [
+      "Envelope.Request.Item.Description", {
+        key: "Envelope.Request.Item.ShortDescription",
+        transform: shortener(14)
+      }
+    ]
   , "length" : "Envelope.Request.Item.Dimensions.Length"
   , "width" : "Envelope.Request.Item.Dimensions.Width"
   , "height" : "Envelope.Request.Item.Dimensions.Height"
   , "inventory.onHandQty" : "Envelope.Request.Item.Inventory"
   , "inventory.replenishQty" : "Envelope.Request.Item.RelpenishQuantity"
+    // Example of new array mapping with members as objects and strings
+  , "shipping.methods[i].name" : [
+      "Envelope.Request.Item.ShippingMethods[i].Type"
+      , {
+        key: "Envelope.Request.Item.ShippingMethodsShortNames[i]"
+        , transform: shortener(3)
+      }
+    ]
+    // Example of adding properties to existing array in TO
+  , "shipping.methods[i].price" : "Envelope.Request.Item.ShippingMethods[i].Price"
+    // Example of empty array mapping
+  , "shipping.options[i]" : "Envelope.Request.Item.ShippingOptions[i]"
 };
 
 var expected = { 
@@ -35,13 +67,26 @@ var expected = {
         SKU: "12345",
         UPC: "99999912345X",
         ShortTitle: "Test Item",
-        ShortDescription: "Description of test item",
+        Description: "Description of test item",
+        ShortDescription: "Description of...",
         Dimensions: { 
           Length: 5, 
           Width: 2, 
           Height: 8 
         },
-        Inventory: 12 
+        Inventory: 12,
+        ShippingMethods: [
+          {Type: "DHL Global Mail (2-8 weeks)", Price: 25},
+          {Type: "Intl USPS w/tracking (1-3 weeks)", Price: 35},
+          {Type: "UPS Worldwide Express", Price: 63}
+        ],
+        ShippingMethodsShortNames: [
+          "DHL...",
+          "Int...",
+          "UPS..."
+        ],
+        ShippingOptions: [
+        ]
       } 
     } 
   } 


### PR DESCRIPTION
Hello Dan,

I am using the object-mapper module in my project and find it very useful, but it is missing some basic support for Arrays mapping which in my case is a must. Therefore I added this support and updated the test case accordingly to show the new functionality in action. Please consider pulling my changes to your repository and push them to npm to avoid duplicate npm repositories with different versions.

Thank you in advance,
David