### PR TITLE
Merge not-undefined values from one object to another

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,19 @@ You may also specify defaults and transforms in two different ways:
   "name" : { 
     key : "firstName"
     , transform : function (value, objFrom, objTo) {
-      return "this returned value will always over ride objTo.firstName";
+      /*
+       * Value returned from `transform` will override `objTo.firstName` only
+       * if it's is not `undefined`, otherwise `default` will be tried.
+       */
+      return typeof value === 'string' ? value : undefined;
     }
     , default : function (objFrom, objTo) {
-      return "this returned value will only over-ride objTo.firstName if objFrom.name is null or undefined";
+      /*
+       * Value returned from `default` will override `objTo.firstName` only
+       * if it's not `undefined` and `objFrom.name` is `undefined`, otherwise
+       * `objTo.firstName` will remain unchanged.
+       */
+      return objFrom.county === "US" ? "John" : undefined;
     }
   , "address" : "emailAddress"
 }

--- a/index.js
+++ b/index.js
@@ -149,10 +149,10 @@ function merge(objFrom, objTo, propMap) {
           value = transform(value, objFrom, objTo);
         }
         
-        if (value || value === 0) {
+        if (typeof value !== 'undefined') {
           setKeyValue(objTo, key, value);
         }
-        else if (def || def === 0) {
+        else if (typeof def !== 'undefined') {
           setKeyValue(objTo, key, def);
         }
       }

--- a/test/test.js
+++ b/test/test.js
@@ -6,12 +6,12 @@ var obj = {
   "sku" : "12345"
   , "upc" : "99999912345X"
   , "title" : "Test Item"
-  , "description" : "Description of test item"
+  , "description" : ""
   , "length" : 5
   , "width" : 2
   , "height" : 8
   , "inventory" : {
-    "onHandQty" : 12
+    "onHandQty" : 0
     , "replenishQty" : null
   }
 }
@@ -35,13 +35,14 @@ var expected = {
         SKU: "12345",
         UPC: "99999912345X",
         ShortTitle: "Test Item",
-        ShortDescription: "Description of test item",
+        ShortDescription: "",
         Dimensions: { 
           Length: 5, 
           Width: 2, 
           Height: 8 
         },
-        Inventory: 12 
+        Inventory: 0,
+        RelpenishQuantity: null
       } 
     } 
   } 


### PR DESCRIPTION
This will allow to merge values like empty string, null of false values. These values are valid and considered meaningful. The only change to semantics of the module is that `transform` and `default` should return `undefined` to disallow merging (previously it can be any value coerced to `false`).

My use case for using object-mapper is to convert objects from one storage to another, preserving values which is defined but can be `false` if coerced to boolean.
