### PR TITLE
Fixed issue with deep properties raising exception on null object.

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function getKeyValue(obj, key, undefined) {
         context = context[subKey];
       }
       else {
-        return context[subKey];
+        return context ? context[subKey] : undefined;
       }
     }
   }

--- a/test/test.js
+++ b/test/test.js
@@ -75,4 +75,13 @@ assert.deepEqual(
   , "Fail! Transform failed"
 );
 
+obj["inventory"] = null;
+expected.Envelope.Request.Item.Inventory = null;
+
+assert.deepEqual(
+  merge(obj, {}, map)
+  , expected
+  , "Fail! Transform failed"
+);
+
 console.error("Success!");


### PR DESCRIPTION
Currently, if you have a deep property mapping using the dot syntax specified in your map, it will throw an exception if an object in the lookup chain to that property is null. For instance, using your example provided in the documentation, if the "inventory" property of the obj is null, you will receive the following error:

    TypeError: Cannot read property 'onHandQty' of null
        at getKeyValue (/Users/abc/object-mapper/node-object-mapper/index.js:55:23)
        at merge (/Users/abc/object-mapper/node-object-mapper/index.js:151:17)
        ...

My change just returns undefined in this case instead, which is the same behavior as the case when a property does not exist on the object.