### PR TITLE
A value of undefined should suppress they key being created on target…

### DIFF
--- a/src/object-mapper.js
+++ b/src/object-mapper.js
@@ -111,6 +111,10 @@ function _mapKey(fromObject, fromKey, toObject, toKey) {
     fromValue = transform(fromValue, fromObject, toObject, fromKey, toKey);
   }
 
+  if (typeof fromValue === 'undefined') {
+    return toObject;
+  }
+
   toObject = setKeyValue(toObject, toKey, fromValue);
 
   if (Array.isArray(restToKeys) && restToKeys.length) {

--- a/test/test.js
+++ b/test/test.js
@@ -895,6 +895,38 @@ test('map object to another - with key object notation with default function whe
   t.end();
 });
 
+test('map object to another - with key object notation with default function returning undefined when key does not exists', function (t) {
+  var obj = {
+    "a" : 1234,
+    "foo": {
+      "bar": "baz"
+    }
+  };
+
+  var expect = {
+    bar: {
+      bar : "baz",
+      a : 1234
+    }
+  };
+
+  var map = {
+    'foo.bar' : 'bar.bar',
+    'notExistingKey': {
+      key: 'bar.test',
+      default: function (fromObject, fromKey, toObject, toKey) {
+        return undefined
+      }
+    },
+    'a' : 'bar.a'
+  };
+
+  var result = om(obj, map);
+
+  t.deepEqual(result, expect);
+  t.end();
+});
+
 test('map object to another - with key object notation with transform', function (t) {
   var baseObject = {
     test: 1


### PR DESCRIPTION
… object

The original algorithm prevented creation of key/value pairs if the value was determined to be undefined. This should be checked after defaults and transforms have been processed. This is the only way of conditionally preventing a key from being created on the target object.

@rafakato, please review.