### PR TITLE
Add documentation for multiple destinations sourced from a single field

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,28 @@ You may also specify array lookups within the source object to be copied to prop
 }
 ```
 
+In order to utilize a source field more than once, utilize the key-transform syntax in the mapping link:
+
+```javascript
+{
+  "foo": [
+    {
+      key: "foo",
+      transform: function (value) {
+        return val + "_foo";
+      }
+    },
+    {
+      key: "baz",
+      transform: function (value) {
+        return val + "_baz"
+      }
+    }
+  ],
+  "bar": "bar"
+}
+```
+
 ###Destination###
 
 You may specify the destination as:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ You may also specify array lookups within the source object to be copied to prop
 }
 ```
 
+###Destination###
+
+You may specify the destination as:
+ - String
+ - Object
+ - Array
+
+####String####
+
+When using string as destination you shall use as described above.
+
 In order to utilize a source field more than once, utilize the key-transform syntax in the mapping link:
 
 ```javascript
@@ -69,17 +80,6 @@ In order to utilize a source field more than once, utilize the key-transform syn
   "bar": "bar"
 }
 ```
-
-###Destination###
-
-You may specify the destination as:
- - String
- - Object
- - Array
-
-####String####
-
-When using string as destination you shall use as described above.
 
 ####Object####
 


### PR DESCRIPTION
Provided a guide on how to use a single field to generate multiple destinations.