### PR TITLE
Allow appending to existing arrays, force explicit null value allow for mapping from keys with null value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,51 @@ When using arrays as destination you can pass a string, object or another array 
 }
 ```
 
+If you want to append items to an existing array, include a '+' after the []
+```javascript
+{
+  "sourceArray[]":{
+    "key":"destination[]+",
+    "transform": (val) => mappingFunction(val)
+  },
+  "otherSourceArray[]":{
+    "key":"destination[]+",
+    "transform:":(val) => mappingFunction(val)
+  }
+}
+// Results in the destination array appending the source values
+{
+  "destination":[
+    {/*Results from mapping function applied to sourceArray */},
+    {/*Results from mapping function applied to otherSourceArray */},
+  ]
+}
+```
+
 The array shorthand for object is defined like:
 
 ```javascript
 [(Key(String))), (Transform(Function())), (Default(String|Number|Function()))]
+```
+
+###Null Values###
+
+By default any source object null value is not mapped. If you want to allow this you may do so explicitly by including the post fix operator '?' to any destination key.
+
+```javascript
+var original = {
+  "sourceKey":null,
+  "otherSourceKey":null
+}
+var transform = {
+  "sourceKey":"canBeNull?",
+  "otherSourceKey":"cannotBeNull"
+}
+var results = ObjectMapper(original, {}, transform);
+// Results would be the following
+{
+  canBeNull:null
+}
 ```
 
 ##Methods##

--- a/src/set-key-value.js
+++ b/src/set-key-value.js
@@ -44,7 +44,7 @@ function _setValue(destinationObject, key, keys, fromValue) {
     , value
     ;
 
-  canBeNull = regCanBeNull.exec(key);
+  canBeNull = regCanBeNull.test(key);
   if(canBeNull){
     key = key.replace(regCanBeNull, '');
   }
@@ -52,8 +52,8 @@ function _setValue(destinationObject, key, keys, fromValue) {
   match = regArray.exec(key);
   appendToArray = regAppendArray.exec(key);
   if (match) {
-      isPropertyArray = true;
-      key = key.replace(regArray, '');
+    isPropertyArray = true;
+    key = key.replace(regArray, '');
     isValueArray = (key !== '');
   }
 

--- a/src/set-key-value.js
+++ b/src/set-key-value.js
@@ -12,6 +12,7 @@ function SetKeyValue(baseObject, destinationKey, fromValue) {
     , key
     ;
 
+
   keys = destinationKey.split(regDot);
   key = keys.splice(0, 1);
 
@@ -31,7 +32,11 @@ module.exports = SetKeyValue;
  */
 function _setValue(destinationObject, key, keys, fromValue) {
   var regArray = /(\[\]|\[(.*)\])$/g
+    , regAppendArray = /(\[\]|\[(.*)\]\+)$/g
+    , regCanBeNull = /(\?)$/g
     , match
+    , appendToArray
+    , canBeNull
     , arrayIndex = 0
     , valueIndex
     , isPropertyArray = false
@@ -39,11 +44,26 @@ function _setValue(destinationObject, key, keys, fromValue) {
     , value
     ;
 
+  // Check from key to see if it allows null values
+  // canBeNull = regCanBeNull.exec(key);
+  // if(canBeNull){
+  //   key = key.replace(regCanBeNull, '');
+  // }
+  // if(!canBeNull && (fromValue === null || fromValue === undefined)){
+  //       return destinationObject;
+  // }
   match = regArray.exec(key);
+  appendToArray = regAppendArray.exec(key);
   if (match) {
-    isPropertyArray = true;
-    key = key.replace(regArray, '');
+      isPropertyArray = true;
+      key = key.replace(regArray, '');
     isValueArray = (key !== '');
+  }
+  if (appendToArray) {
+    match = appendToArray;
+    isPropertyArray = true;
+    isValueArray = (key !== '');
+    key = key.replace(regAppendArray, '');
   }
 
   if (_isEmpty(destinationObject)) {
@@ -69,9 +89,13 @@ function _setValue(destinationObject, key, keys, fromValue) {
       if (Array.isArray(destinationObject[key]) === false) {
         destinationObject[key] = [];
       }
-      destinationObject[key][arrayIndex] = fromValue;
+      if(appendToArray){
+          destinationObject[key].push(fromValue);
+      } else{
+        destinationObject[key][arrayIndex] = fromValue;
+      }
     } else if (Array.isArray(destinationObject)) {
-      destinationObject[arrayIndex] = fromValue;
+        destinationObject[arrayIndex] = fromValue;
     } else {
       destinationObject[key] = fromValue;
     }

--- a/src/set-key-value.js
+++ b/src/set-key-value.js
@@ -44,14 +44,11 @@ function _setValue(destinationObject, key, keys, fromValue) {
     , value
     ;
 
-  // Check from key to see if it allows null values
-  // canBeNull = regCanBeNull.exec(key);
-  // if(canBeNull){
-  //   key = key.replace(regCanBeNull, '');
-  // }
-  // if(!canBeNull && (fromValue === null || fromValue === undefined)){
-  //       return destinationObject;
-  // }
+  canBeNull = regCanBeNull.exec(key);
+  if(canBeNull){
+    key = key.replace(regCanBeNull, '');
+  }
+
   match = regArray.exec(key);
   appendToArray = regAppendArray.exec(key);
   if (match) {
@@ -59,6 +56,7 @@ function _setValue(destinationObject, key, keys, fromValue) {
       key = key.replace(regArray, '');
     isValueArray = (key !== '');
   }
+
   if (appendToArray) {
     match = appendToArray;
     isPropertyArray = true;
@@ -85,6 +83,9 @@ function _setValue(destinationObject, key, keys, fromValue) {
     }
   }
   if (keys.length === 0) {
+    if(!canBeNull && (fromValue === null || fromValue === undefined)){
+      return destinationObject;
+    }
     if (isValueArray) {
       if (Array.isArray(destinationObject[key]) === false) {
         destinationObject[key] = [];

--- a/test/test.js
+++ b/test/test.js
@@ -1538,6 +1538,7 @@ test('map object to another - allow null values', function (t) {
   t.deepEqual(result, expect);
   t.end();
 });
+
 test('map object to another - allow null values', function (t) {
   var obj = {
     "a" : 1234,
@@ -1598,7 +1599,7 @@ test('original various tests', function (t) {
     , "weightUnits": [["Envelope.Request.Item.WeightUnits", null, function () {
       return null;
     }]]
-    , "inventory.onHandQty": "Envelope.Request.Item.Inventory"
+    , "inventory.onHandQty": "Envelope.Request.Item.Inventory?"
     , "inventory.replenishQty": "Envelope.Request.Item.RelpenishQuantity?"
     , "inventory.isInventoryItem": {key: ["Envelope.Request.Item.OnInventory", null, "YES"]}
     , "price": ["Envelope.Request.Item.Price[].List", "Envelope.Request.Item.Price[].Value", "Test[]"]
@@ -1651,6 +1652,12 @@ test('original various tests', function (t) {
 
   t.deepEqual(result, expected, 'override sku');
 
+  obj["inventory"] = null;
+   expected.Envelope.Request.Item.Inventory = null;
+
+   result = merge(obj, {}, map);
+
+   t.deepEqual(result, expected, 'null inventory');
 
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1485,6 +1485,88 @@ test('mapping - map and append full array to existing mapped array', function (t
   t.end();
 });
 
+test('map object to another - prevent null values from being mapped', function (t) {
+  var obj = {
+    "a" : 1234,
+    "foo": {
+      "bar": null
+    }
+  };
+
+  var expect = {
+    foo:{
+      a:1234
+    },
+    bar:{
+
+    }
+  };
+
+  var map = {
+    'foo.bar' : 'bar.bar',
+    'a': 'foo.a'
+   };
+
+  var result = om(obj, map);
+
+  t.deepEqual(result, expect);
+  t.end();
+});
+
+test('map object to another - allow null values', function (t) {
+  var obj = {
+    "a" : 1234,
+    "foo": {
+      "bar": null
+    }
+  };
+
+  var expect = {
+    foo:{
+      a:1234
+    },
+    bar:null
+  };
+
+  var map = {
+    'foo.bar' : 'bar?',
+    'a': 'foo.a'
+   };
+
+  var result = om(obj, map);
+
+  t.deepEqual(result, expect);
+  t.end();
+});
+test('map object to another - allow null values', function (t) {
+  var obj = {
+    "a" : 1234,
+    "foo": {
+      "bar": null
+    }
+  };
+
+  var expect = {
+    foo:{
+      a:1234
+    },
+    bar:{
+      bar:null
+    }
+  };
+
+  var map = {
+    'foo.bar' : 'bar.bar?',
+    'a': 'foo.a'
+   };
+
+  var result = om(obj, map);
+
+  t.deepEqual(result, expect);
+  t.end();
+});
+
+
 test('original various tests', function (t) {
   var merge = require('../').merge;
 
@@ -1517,7 +1599,7 @@ test('original various tests', function (t) {
       return null;
     }]]
     , "inventory.onHandQty": "Envelope.Request.Item.Inventory"
-    , "inventory.replenishQty": "Envelope.Request.Item.RelpenishQuantity"
+    , "inventory.replenishQty": "Envelope.Request.Item.RelpenishQuantity?"
     , "inventory.isInventoryItem": {key: ["Envelope.Request.Item.OnInventory", null, "YES"]}
     , "price": ["Envelope.Request.Item.Price[].List", "Envelope.Request.Item.Price[].Value", "Test[]"]
     , "descriptions[0]": "Envelope.Request.Item.ShortDescription"
@@ -1538,7 +1620,6 @@ test('original various tests', function (t) {
             Height: 8
           },
           Weight: 10,
-          WeightUnits: null,
           Inventory: 0,
           RelpenishQuantity: null,
           OnInventory: 'YES',
@@ -1570,13 +1651,6 @@ test('original various tests', function (t) {
 
   t.deepEqual(result, expected, 'override sku');
 
-
-  obj["inventory"] = null;
-  expected.Envelope.Request.Item.Inventory = null;
-
-  result = merge(obj, {}, map);
-
-  t.deepEqual(result, expected, 'null inventory');
 
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1653,11 +1653,11 @@ test('original various tests', function (t) {
   t.deepEqual(result, expected, 'override sku');
 
   obj["inventory"] = null;
-   expected.Envelope.Request.Item.Inventory = null;
+  expected.Envelope.Request.Item.Inventory = null;
 
-   result = merge(obj, {}, map);
+  result = merge(obj, {}, map);
 
-   t.deepEqual(result, expected, 'null inventory');
+  t.deepEqual(result, expected, 'null inventory');
 
   t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1408,7 +1408,7 @@ test('mapping - map full array without destination key via transform', function 
         var a = val.reduce(function (i, obj) {
           return i += obj.a;
         }, '');
-  
+
         dst.manual = a
       }
     , null ]]
@@ -1442,6 +1442,40 @@ test('mapping - map full array to same array on destination side', function (t) 
       {a: 'a1', b: 'b1'}
       , {a: 'a2', b: 'b2'}
       , {a: 'a3', b: 'b3'}
+    ]
+  };
+
+  var result = om(obj, map);
+
+  t.deepEqual(result, expect);
+  t.end();
+});
+
+test('mapping - map and append full array to existing mapped array', function (t) {
+  var obj = {
+    thing : [
+      {a: 'a1', b: 'b1'}
+      , {a: 'a2', b: 'b2'}
+      , {a: 'a3', b: 'b3'}
+    ],
+    thingOther:[{a: 'a4', b: 'b4'}
+    , {a: 'a5', b: 'b5'}
+    , {a: 'a6', b: 'b6'}]
+  };
+
+  var map = {
+    'thing' : 'thing2[]+',
+    'thingOther' : 'thing2[]+',
+  };
+
+  var expect = {
+    'thing2' : [
+      [{a: 'a1', b: 'b1'}
+      , {a: 'a2', b: 'b2'}
+      , {a: 'a3', b: 'b3'}],
+      [{a: 'a4', b: 'b4'}
+      , {a: 'a5', b: 'b5'}
+      , {a: 'a6', b: 'b6'}]
     ]
   };
 


### PR DESCRIPTION
I'm not sure if this is too specific to our use case, but we found that it was tricky when we wanted to push items onto a newly mapped array, we would constantly be writing over the initial transform. This change allows you to specify 

```javascript
source[]:{
  key:'destination[]+',
  transform: (val)=> mappingFunction(val)
},
someOtherSource[]:{
  key:'destination[]+',
  transform: (val)=> mappingFunction(val)
}

outputs

{
  destination:[
    {/*mappedObject from mappingFunction*/},
    {/*other mappedObject from the mappingFunction*/}
  ]
}
```
Which would then append the value to the existing array.

We also wanted to minimize the footprint of our transformation, so we wanted null values to be excluded in the mapping, unless explicitly specified with an postfix like opertator

```javascript
var sourceObject = {
  source:null,
  source2:null
},
mappingObject = {
  source:destinationMapNullValues?,
  source2:desinationDoNotMapNull
};

The result of the transform is
{
  destinationMapNullValues:null
}
```