### PR TITLE
remove unneccessary deep clone

### DIFF
--- a/src/set-key-value.js
+++ b/src/set-key-value.js
@@ -77,7 +77,6 @@ function _setValue(destinationObject, key, keys, fromValue) {
       destinationObject = {};
     }
   } else {
-    destinationObject = JSON.parse(JSON.stringify(destinationObject));
     if (isPropertyArray) {
       arrayIndex = match[2] || 0;
     }

--- a/test/test.js
+++ b/test/test.js
@@ -1281,7 +1281,7 @@ test('array mapping - from/to specific indexes', function (t) {
 
   var expect = {
     "comments": [
-      null, {c: 'a1', d: 'b1'}
+      , {c: 'a1', d: 'b1'}
     ]
   };
 


### PR DESCRIPTION
This change is intended to resolve the strange behavior described by https://github.com/wankdanker/node-object-mapper/issues/25

Deep cloning the output object using `JSON.stringify` & `JSON.parse` eliminates the ability to use complex data types. Removing this deep clone entirely only fails one test, changing a behavior in which a `undefined` array value gets converted to `null` in the process of deep cloning with JSON. Since this behavior appears to be a side effect and not the primary target of the test, I've adjusted the test slightly to stay true to the description of the test but not rely on this side effect behavior of converting to and from JSON in validating the outcome.