### PR TITLE
return key value when key value is undefined

### DIFF
--- a/src/get-key-value.js
+++ b/src/get-key-value.js
@@ -78,7 +78,7 @@ function _getValue(fromObject, key, keys) {
 
   if (keys.length === 0) {
     if (isValueArray) {
-      if (typeof arrayIndex === 'undefined') {
+      if (typeof arrayIndex === 'undefined' || fromObject[key] === undefined) {
         result = fromObject[key];
       } else {
         result = fromObject[key][arrayIndex];


### PR DESCRIPTION
return `fromObject[key]` if undefined since there is no point going any further. Fixes #34 