### PR TITLE
Fix for multiple literal dots and fix for when the backslash itself i…

### DIFF
--- a/src/get-key-value.js
+++ b/src/get-key-value.js
@@ -8,15 +8,38 @@
  * @returns {*}
  */
 function GetKeyValue(fromObject, fromKey) {
-  var regDot = /\./g
-    , regFinishArray = /.+(\[\])/g
+  var regFinishArray = /.+(\[\])/g
     , keys
     , key
     , result
     , lastValue
+    , merged = []
     ;
 
-  keys = fromKey.split(regDot);
+  // matches only unescaped dots
+  var regDot = /([^\\])(\\\\)*\./g;
+  var keys = fromKey.split(regDot);
+  for (var i = 0; i < keys.length; i++) {
+    if ((i - 1) % 3 === 0) {
+      // Every third match is the character of
+      // the first group [^\\] which
+      // is the last character of the key.
+      // Merge it in again.
+      var tmpKey = keys[i - 1] + keys[i];
+      if (keys[i + 1]) {
+        // If second group is found, this means
+        // that the backslash itself is escaped.
+        // Retain unchanged as well.
+        tmpKey += keys[i + 1];
+      }
+      merged.push(tmpKey.replace(/\\\./g, "."));
+    }
+    // Add part after last dot
+    if (i === keys.length - 1) {
+      merged.push(keys[i].replace(/\\\./g, "."));
+    }
+  }
+  keys = merged;
   key = keys.splice(0, 1);
   lastValue = fromKey.match(regFinishArray);
   if(lastValue != null && lastValue[0] === fromKey){

--- a/src/set-key-value.js
+++ b/src/set-key-value.js
@@ -15,13 +15,20 @@ function SetKeyValue(baseObject, destinationKey, fromValue) {
     if ((i - 1) % 3 === 0) {
       // Every third match is the character of
       // the first group [^\\] which
-      // needs to be merged in again
+      // is the last character of the key.
+      // Merge it in again.
       var tmpKey = keys[i - 1] + keys[i];
-      merged.push(tmpKey.replace("\\.", "."));
+      if (keys[i + 1]) {
+        // If second group is found, this means
+        // that the backslash itself is escaped.
+        // Retain unchanged as well.
+        tmpKey += keys[i + 1];
+      }
+      merged.push(tmpKey.replace(/\\\./g, "."));
     }
     // Add part after last dot
     if (i === keys.length - 1) {
-      merged.push(keys[i].replace("\\.", "."));
+      merged.push(keys[i].replace(/\\\./g, "."));
     }
   }
   keys = merged;

--- a/test/test.js
+++ b/test/test.js
@@ -1719,11 +1719,7 @@ test('map array inside array to property', function (t) {
   t.end();
 });
 
-test('Mapping source key properties with dots', function (t) {
-  var baseObject = {
-    test: 1
-  };
-
+test('Mapping destination property with a literal dot', function (t) {
   var obj = {
     "foo": {
       "bar": "baz"
@@ -1731,7 +1727,6 @@ test('Mapping source key properties with dots', function (t) {
   };
 
   var expect = {
-    test: 1,
     "bar.baz": "baz"
   };
 
@@ -1744,16 +1739,13 @@ test('Mapping source key properties with dots', function (t) {
     }
   };
 
-  var result = om(obj, baseObject, map);
+  var result = om(obj, map);
 
   t.deepEqual(result, expect);
   t.end();
 });
 
-test('Mapping source key properties with wrong escaped dot', function (t) {
-  var baseObject = {
-    test: 1
-  };
+test('Mapping destination property with wrong escaped dot', function (t) {
 
   var obj = {
     "foo": {
@@ -1762,7 +1754,6 @@ test('Mapping source key properties with wrong escaped dot', function (t) {
   };
 
   var expect = {
-    test: 1,
     "bar": {"baz": "baz"}
   };
 
@@ -1775,11 +1766,61 @@ test('Mapping source key properties with wrong escaped dot', function (t) {
     }
   };
 
-  var result = om(obj, baseObject, map);
+  var result = om(obj, map);
 
   t.deepEqual(result, expect);
   t.end();
 });
 
+test('Mapping destination property with two escaped dots', function (t) {
+  var obj = {
+    "foo": {
+      "bar": "baz"
+    }
+  };
+
+  var expect = {
+    "bar.baz.duz": "baz"
+  };
+
+  var map = {
+    'foo.bar': {
+      key: 'bar\\.baz\\.duz',
+      transform: function (value, fromObject, toObject, fromKey, toKey) {
+        return value;
+      }
+    }
+  };
+
+  var result = om(obj, map);
+
+  t.deepEqual(result, expect);
+  t.end();
+});
+
+test('Mapping destination property with backslash itself escaped', function (t) {
+  var obj = {
+    "foo": {
+      "bar": "baz"
+    }
+  };
+
+  var expect = {
+    "bar\\\\": { "baz": "baz" }
+  };
+  var map = {
+    'foo.bar': {
+      key: 'bar\\\\.baz',
+      transform: function (value, fromObject, toObject, fromKey, toKey) {
+        return value;
+      }
+    }
+  };
+
+  var result = om(obj, map);
+
+  t.deepEqual(result, expect);
+  t.end();
+});
 
 


### PR DESCRIPTION
…s escaped.


Contains two fixes:

a) keys with several literal dots did not work previously , e.g. "baz\\\\.bar\\\\.foo"
b) keys where the backslash itself is escaped were erroneously stripped out completely: "baz\\\\\\\\.bar"