### PR TITLE
Mark parameters toObject and propertyMap as optional

### DIFF
--- a/src/object-mapper.js
+++ b/src/object-mapper.js
@@ -8,8 +8,8 @@ var getKeyValue = require('./get-key-value')
 /**
  * Map a object to another using the passed map
  * @param fromObject
- * @param toObject
- * @param propertyMap
+ * @param [toObject]
+ * @param [propertyMap]
  * @returns {*}
  * @constructor
  */


### PR DESCRIPTION
When using `objectMapper` without `propertyMap` parameter in project with `typescript` or `checkJs` enabled as so
```javascript
new objectMapper(fromObject,  toObject)
```
Compiler complaint about last parameter not provided:

![{C4957CDB-3CCA-4CC5-B197-DA6A2DCE9940} png](https://user-images.githubusercontent.com/31159198/66524012-e5858580-eaf9-11e9-999d-d7f05b09cb93.jpg)

Also from looking at the implementation `toObject` parameter is also optional so marking both as optional removes the type error

Maybe Also marking the function with `@constructor` is unnecessary as there is no using of `this` in the implementation and the function can be used without the word `new`