### PR TITLE
Fix #65 where a null default is specified

### DIFF
--- a/src/object-mapper.js
+++ b/src/object-mapper.js
@@ -328,7 +328,7 @@ function set_data(dest, key, data, context)
   }
 
   // See if data is null and there is a default
-  if (context.default && (data == null || typeof data == 'undefined')) {
+  if (typeof context.default !== 'undefined' && (data == null || typeof data == 'undefined')) {
     // There is a default function, call the function to set the default
     if (typeof context.default == 'function') {
       dest = dest || {}
@@ -341,7 +341,8 @@ function set_data(dest, key, data, context)
 
   // Set the object to the data if it is not undefined
   if (typeof data !== 'undefined' && key && key.name) {
-    if (data !== null || key.nulls) {
+    // Set the data if the data is not null, or if the 'allow nulls' key is set, or if there is a default (in the case of default=null, make sure to write this out)
+    if (data !== null || key.nulls || (typeof context.default !== 'undefined' && context.default == null)) {
       dest = dest || {}
       dest[key.name] = data
     }

--- a/test/test.js
+++ b/test/test.js
@@ -100,6 +100,24 @@ test('PARSE with deep brackets', function (t) {
   t.deepEqual(result, expect);
   t.end();
 });
+test('MAP with empty default on missing key', function (t) {
+  var obj = {foo: 'bar'}
+  var map = {'undefined_key': {key:'key_with_default', default:''}}
+  var expect = {key_with_default: ''}
+
+  var result = om(obj, map);
+  t.deepEqual(result, expect);
+  t.end();
+});
+test('MAP with null default on missing key', function (t) {
+  var obj = {foo: 'bar'}
+  var map = {'undefined_key': {key:'key_with_default', default: null}}
+  var expect = {key_with_default: null}
+
+  var result = om(obj, map);
+  t.deepEqual(result, expect);
+  t.end();
+});
 // test('parse with a slashed dot', function (t) {
 //   var k = 'abc\.def'
 //   var expect = ['[abc.def']


### PR DESCRIPTION
Fix for issue #65.  If the map specifies a null default value, that value should be written out.  Note that this makes the `?` feature redundant (allow nulls), because instead of the `?` you can just add `default: null` to your definition.