### PR TITLE
[#68 ]bugfix: mapping array of objects using transforms

### DIFF
--- a/src/object-mapper.js
+++ b/src/object-mapper.js
@@ -271,7 +271,7 @@ function update_arr(dest, key, data, keys, context)
   if (key.add) {
     if (data !== null && typeof data !== 'undefined') {
       dest = dest || []
-      dest.push(data)
+      dest.push(applyTransform(data,dest,context))
       // dest = dest.concat(data)
     }
     return dest
@@ -279,7 +279,7 @@ function update_arr(dest, key, data, keys, context)
 
   // Just update a single array node
   if (key.ix !== '') {
-    return update_arr_ix(dest, key.ix, data, keys, context)
+    return update_arr_ix(dest, key.ix, applyTransform(data,dest,context), keys, context)
   }
 
   // If the data is in an array format then make sure that there is a dest index for each data index
@@ -289,7 +289,7 @@ function update_arr(dest, key, data, keys, context)
     dest = data.reduce(function(dest,d,i) {
       // If the instruction is to update all array indices ('') or the current index, update the child data element.  Otherwise, don't bother
       if (key.ix == '' || key.ix == i) {
-        return update_arr_ix(dest, i, d, keys.slice(), context)
+        return update_arr_ix(dest, i, applyTransform(d,dest,context), keys.slice(), context)
       }
     }, dest)
 
@@ -299,6 +299,14 @@ function update_arr(dest, key, data, keys, context)
   // Set the specific array index with the data
   else 
     return update_arr_ix(dest, '0', data, keys, context)
+}
+
+function applyTransform(data, dest, context){
+  if (typeof context.transform == 'function') {
+    return context.transform(data, context.src, dest, context.srckey, context.destkey)
+  }else{
+    return data;
+  }
 }
 
 function update_arr_ix(dest, ix, data, keys, context)

--- a/test/test.js
+++ b/test/test.js
@@ -2530,3 +2530,24 @@ test('MAP Should correctly create an array and add if undlerlying data structure
   t.deepEqual(result, expect)
   t.end()
 });
+
+
+
+test("MAP Should correctly apply transform in array data #68", t => {
+  var src = {
+    test: ["1234", "5678", "9101"]
+  };
+  var map = {
+    "test[]": {
+      key: "check[]",
+      transform: val => parseInt(val)
+    }
+  };
+  var expect = {
+    check: [1234, 5678, 9101]
+  };
+  var result = om(src, map);
+
+  t.deepEqual(result, expect);
+  t.end();
+});


### PR DESCRIPTION
Solved issue #68, with this changes it's possible use transform functions in array mapping.