### PR TITLE
Negative array indexes

### DIFF
--- a/src/object-mapper.js
+++ b/src/object-mapper.js
@@ -94,8 +94,8 @@ function select_arr(src, key, keys)
     return data
 
   // Return a specific node in the array if defined
-  if (key.ix && typeof data[key.ix] !== 'undefined')
-    return data[key.ix]
+  if (key.ix && typeof negative_array_access(data, key.ix) !== 'undefined')
+    return negative_array_access(data, key.ix);
 
   // If we are not expecting an array, return the first node - kinda hacky
   if (typeof data[0] !== 'undefined' && key.name && data[0][key.name])
@@ -103,6 +103,13 @@ function select_arr(src, key, keys)
   
   // Otherwise, return nothing
   return null
+}
+
+// Allows negative array indexes to count down from end of array
+function negative_array_access(arr, ix)
+{
+  var pix = parseInt(ix);
+  return pix < 0 ? arr[arr.length + pix] : arr[ix];
 }
 
 // Traverse the given object for data using the given key array

--- a/test/test.js
+++ b/test/test.js
@@ -207,6 +207,36 @@ test('get value - simple array defined index', function (t) {
   t.end();
 });
 
+test('get value - simple array negative index', function (t) {
+  var obj = ['foo', 'bar'];
+  var map = '[-1]';
+  var expect = 'bar';
+  var result = om.getKeyValue(obj, map);
+
+  t.deepEqual(result, expect);
+  t.end();
+});
+
+test('get value - simple array dot property', function (t) {
+  var obj = [{ name: 'foo' }, { name: 'bar' }];
+  var map = '[-1].name';
+  var expect = 'bar';
+  var result = om.getKeyValue(obj, map);
+
+  t.deepEqual(result, expect);
+  t.end();
+});
+
+test('get value - simple array negative index falls off array', function (t) {
+  var obj = ['foo', 'bar'];
+  var map = '[-3]';
+  var expect = null;
+  var result = om.getKeyValue(obj, map);
+
+  t.deepEqual(result, expect);
+  t.end();
+});
+
 test('get value - two levels deep', function (t) {
   var key = 'foo.baz.fog';
 
@@ -383,6 +413,28 @@ test('get value - crazy', function (t) {
   t.deepEqual(result, expect);
   t.end();
 });
+
+test('get value - crazy negative', function (t) {
+  var key = 'foo.baz[-1].fog[1].baz';
+
+  var obj = {
+    "foo": {
+      "baz": [{
+        "fog": [, {
+          "baz": "bar"
+        }]
+      }]
+    }
+  };
+
+  var expect = "bar";
+
+  var result = om.getKeyValue(obj, key);
+
+  t.deepEqual(result, expect);
+  t.end();
+});
+
 
 test('select with array object where map is not an array 1', function (t) {
   var obj = { foo: [{bar: 'a'}, {bar: 'b'}, {bar: 'c'}] }


### PR DESCRIPTION
- allows for Python/Go/etc style negative array index access
- a negative array index will be counted from the end of the array
- for example the map `{ "results[-1].id": "lastId" }` will map the id of the last result to `lastId`
- a negative array index whos absolute value is greater than the arrays length returns undefined
- while this doesn't work the other way (`{ "lastItem": "items[-1]" }`), the result of that sort of mapping is unchanged, and so no new surprising behaviors are introduced by this change