### PR TITLE
[#80] fix null value check not iterating correctly in arrays

### DIFF
--- a/src/object-mapper.js
+++ b/src/object-mapper.js
@@ -85,7 +85,8 @@ function select_arr(src, key, keys)
     // Check to see if we are at a 'leaf' (no more keys to parse).  If so, return the data.  If not, recurse
     var d = (keys.length) ? select(src[i], keys.slice()) : src[i]
     // If the data is populated, add it to the array.  Make sure to keep the same array index so that traversing multi-level arrays work
-    if (d !== null)
+    // If data is null, the subsequent steps will take the default value if there is one, and null if null is allowed.
+    if ( typeof d !== 'undefined')
       data[i] = d
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -2656,3 +2656,49 @@ test("issue #74: mapping empty array should result in empty array", t => {
   t.deepEqual(result, expect);
   t.end();
 });
+
+test('Ensure that null value check is iterated correctly in arrays', function (t) {
+  const src = {
+    "source": [
+      {
+        "some": "value",
+        "empty": null
+      },
+      {
+        "some": "value",
+        "empty": null
+      },
+      {
+        "some": "value",
+        "empty": null
+      }
+    ]
+  };
+
+  const map =  {
+    "source[].some": "destination[].some",
+    "source[].empty": "destination[].empty?"
+  };
+
+  const expect = {
+    "destination": [
+      {
+        "some": "value",
+        "empty": null
+      },
+      {
+        "some": "value",
+        "empty": null
+      },
+      {
+        "some": "value",
+        "empty": null
+      }
+    ]
+  }
+
+  const result = om(src, map);
+
+  t.deepEqual(result, expect);
+  t.end();
+});


### PR DESCRIPTION
Null values on the source object is only mapped for the first element of an array (when a post-fix operator '?' is used).

Test 102 for issue [#41 ](https://github.com/wankdanker/node-object-mapper/issues/41) is now failing because the code returns [null] while the test is expecting null.  I don't quiet agree with the expected result.

for further details, refer to [#80](https://github.com/wankdanker/node-object-mapper/issues/80 )